### PR TITLE
^^1.14.2を^1.14.2に変更

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "start": "NODE_ENV=\"development\" node --env-file .env --watch src/app.js"
   },
   "dependencies": {
-    "@hono/node-server": "^^1.14.2",
+    "@hono/node-server": "^1.14.2",
     "@hono/oauth-providers": "0.8.0",
     "hono": "^4.7.10",
     "iron-session": "8.0.1"


### PR DESCRIPTION
package.json の "@hono/node-server" のバージョンを
"^^1.14.2" から "^1.14.2" に修正しました。

以前の "^^" という形式では yarn/npm でインストール時に
エラーが発生していました。本修正により依存関係を
正しくインストールできるようになります。